### PR TITLE
Remove Rotation from Maps

### DIFF
--- a/config/bev_node.lua
+++ b/config/bev_node.lua
@@ -13,6 +13,7 @@ BEVParameters = {
     bev_horizon_distance = 5.0;
 
     stitched_bev_image_topic = "/bev/stitched";
+    stitched_bev_angle_topic = "/bev/stitched_angle";
     stitched_bev_horizon_distance = 6.0;
     stitched_bev_ema_gamma = 0.5;
 

--- a/src/bev/bev_stitcher.h
+++ b/src/bev/bev_stitcher.h
@@ -14,6 +14,7 @@ class BevStitcher {
   void UpdateBev(const cv::Mat3b& image);
   cv::Mat3b UpdatePose(const Eigen::Vector3f& position,
                        const Eigen::Quaternionf& orientation);
+  float GetRobotMapAngle() const;
 
  protected:
   void StitchBev();


### PR DESCRIPTION
This PR removes the rotation from the published stitched map and instead publishes that rotation angle to a new topic. The orientation of the stitched map is fixed, with the new BEV images being rotated according to the angle before being added.