### PR TITLE
Subscribe to input image topic with image_transport

### DIFF
--- a/config/bev_node.lua
+++ b/config/bev_node.lua
@@ -4,7 +4,7 @@ end
 
 BEVParameters = {
     camera_calibration_config_path = "config/camera_calibration_kinect.yaml";
-    input_image_topic = "/camera/rgb/image_raw/compressed";
+    input_image_topic = "/camera/rgb/image_raw";
     input_image_width = 1920;
     input_image_height = 1080;
 

--- a/src/bev_node/bev_node_main.cc
+++ b/src/bev_node/bev_node_main.cc
@@ -76,7 +76,7 @@ Eigen::Matrix3f ReadIntrinsicMatrix() {
   }
 }
 
-void InputImageCallback(const sensor_msgs::CompressedImageConstPtr msg) {
+void InputImageCallback(const sensor_msgs::ImageConstPtr& msg) {
   cv_bridge::CvImagePtr cv_image =
       cv_bridge::toCvCopy(msg, sensor_msgs::image_encodings::BGR8);
 
@@ -123,8 +123,10 @@ int main(int argc, char** argv) {
   ros::NodeHandle node_handle;
   image_transport::ImageTransport image_transport(node_handle);
 
-  ros::Subscriber input_image_subscriber =
-      node_handle.subscribe(CONFIG_input_image_topic, 1, &InputImageCallback);
+  image_transport::Subscriber input_image_subscriber =
+      image_transport.subscribe(CONFIG_input_image_topic, 1,
+                                &InputImageCallback,
+                                image_transport::TransportHints("compressed"));
   ros::Subscriber pose_subscriber =
       node_handle.subscribe(CONFIG_pose_topic, 1, &PoseCallback);
 


### PR DESCRIPTION
Using the `image_transport` package for image subscribes allows the specification of a particular encoding subtopic (e.g. `compressed` or `raw`) at runtime. The `raw` encoding consumes more bandwidth but requires less cpu utilization for both the publisher and subscriber by bypassing compression and decompression, making it suitable for situations in which all nodes are running on the same machine.

On my machine, using `depth_to_lidar` @ 1536p, 15fps,

- With the `compressed` encoding, `depth_to_lidar` consumes 82% cpu, `bev_node` consumes 87% cpu, and the inter-node bandwidth is 2.2 MB/s.
- With the `raw` encoding, `depth_to_lidar` consumes 48% cpu, `bev_node` consumes 48% cpu, and the inter-node bandwidth is 185 MB/s.

The default encoding remains `compressed` to retain compatibility with rosbags and other existing use cases. The `raw` encoding can be specified on the command line as `bin/bev_node _image_transport:=raw`.