### PR TITLE
Update stitched BEV only after some delta

### DIFF
--- a/config/bev_node.lua
+++ b/config/bev_node.lua
@@ -15,7 +15,10 @@ BEVParameters = {
     stitched_bev_image_topic = "/bev/stitched";
     stitched_bev_angle_topic = "/bev/stitched_angle";
     stitched_bev_horizon_distance = 6.0;
-    stitched_bev_ema_gamma = 0.5;
+    stitched_bev_ema_gamma = 0.1;
+    stitched_bev_update_distance = 1.0; -- meters
+    stitched_bev_update_angle = 10; -- degrees
+
 
     pose_topic = "/husky_inekf_estimation/pose";
 

--- a/src/bev/bev_stitcher.cc
+++ b/src/bev/bev_stitcher.cc
@@ -82,10 +82,14 @@ void BevStitcher::StitchBev() {
   for (int y = 0; y < bev_resized.rows; y++) {
     for (int x = 0; x < bev_resized.cols; x++) {
       auto bev_pixel = bev_resized.at<cv::Vec3b>(y, x);
-      if (cv::norm(bev_pixel) > stitch_overlay_threshold_)
-        stitched_bev_.at<cv::Vec3b>(y, x) =
-            ema_gamma_ * stitched_bev_.at<cv::Vec3b>(y, x) +
-            (1 - ema_gamma_) * bev_pixel;
+      if (cv::norm(bev_pixel) > stitch_overlay_threshold_) {
+        cv::Vec3b& stitched_pixel = stitched_bev_.at<cv::Vec3b>(y, x);
+        if (cv::norm(stitched_pixel) > stitch_overlay_threshold_)
+          stitched_pixel =
+              ema_gamma_ * stitched_pixel + (1 - ema_gamma_) * bev_pixel;
+        else
+          stitched_pixel = bev_pixel;
+      }
     }
   }
 }

--- a/src/bev/bev_stitcher.cc
+++ b/src/bev/bev_stitcher.cc
@@ -25,9 +25,8 @@ BevStitcher::BevStitcher(const int input_image_rows, const int input_image_cols,
       stitch_overlay_threshold_(stitch_overlay_threshold) {
   // the stitched BEV map places the robot in the center of the image so the
   // image spans horizon_distance_ in the x and y axes from the robot
-  stitched_bev_ =
-      cv::Mat::zeros(2 * pixels_per_meter_ * horizon_distance_,
-                     2 * pixels_per_meter_ * horizon_distance_, CV_32F);
+  stitched_bev_ = cv::Mat3b::zeros(2 * pixels_per_meter_ * horizon_distance_,
+                                   2 * pixels_per_meter_ * horizon_distance_);
 }
 
 void BevStitcher::UpdateBev(const cv::Mat3b& image) {

--- a/src/bev/bev_stitcher.h
+++ b/src/bev/bev_stitcher.h
@@ -8,7 +8,8 @@ class BevStitcher {
  public:
   BevStitcher(const int input_image_rows, const int input_image_cols,
               const float pixels_per_meter, const float horizon_distance,
-              const float ema_gamma,
+              const float ema_gamma, const float update_distance,
+              const float update_angle,
               const float stitch_overlay_threshold = 1.0);
 
   void UpdateBev(const cv::Mat3b& image);
@@ -28,6 +29,8 @@ class BevStitcher {
 
   Eigen::Vector3f last_position_;
   Eigen::Quaternionf last_orientation_;
+  Eigen::Vector3f last_stitch_position_;
+  Eigen::Quaternionf last_stitch_orientation_;
 
   const int input_image_rows_;
   const int input_image_cols_;
@@ -35,6 +38,8 @@ class BevStitcher {
   const float horizon_distance_;
 
   const float ema_gamma_;
+  const float update_distance_;
+  const float update_angle_;
   const float stitch_overlay_threshold_;
 };
 }  // namespace bev

--- a/src/bev_node/bev_node_main.cc
+++ b/src/bev_node/bev_node_main.cc
@@ -34,6 +34,10 @@ CONFIG_STRING(stitched_bev_angle_topic,
 CONFIG_FLOAT(stitched_bev_horizon_distance,
              "BEVParameters.stitched_bev_horizon_distance");
 CONFIG_FLOAT(stitched_bev_ema_gamma, "BEVParameters.stitched_bev_ema_gamma");
+CONFIG_FLOAT(stitched_bev_update_distance,
+             "BEVParameters.stitched_bev_update_distance");
+CONFIG_FLOAT(stitched_bev_update_angle,
+             "BEVParameters.stitched_bev_update_angle");
 
 CONFIG_STRING(pose_topic, "BEVParameters.pose_topic");
 
@@ -144,7 +148,8 @@ int main(int argc, char** argv) {
   auto bev_size = bev_transformer_->GetBevSize();
   bev_stitcher_ = std::make_unique<bev::BevStitcher>(
       bev_size.height, bev_size.width, CONFIG_bev_pixels_per_meter,
-      CONFIG_stitched_bev_horizon_distance, CONFIG_stitched_bev_ema_gamma);
+      CONFIG_stitched_bev_horizon_distance, CONFIG_stitched_bev_ema_gamma,
+      CONFIG_stitched_bev_update_distance, CONFIG_stitched_bev_update_angle);
 
   ros::spin();
 


### PR DESCRIPTION
Adds two parameters that adjust the stitching behavior of the `BevStitcher` to only perform stitching of a new BEV image after some minimum change in either translation or rotation. The stitched BEV image is still translated on every pose update, however, so that any planning can still be done with the most recent stitched BEV image.

## Additions
- the `stitched_bev_update_distance` config option defines the minimum translation needed to trigger stitching
- the `stitched_bev_update_angle` config option defines the minimum rotation needed to trigger stitching

## Other changes
- updates the logic used for doing the actual stitching to never average with blank pixels. If a pixel is empty, it is simply overwritten.