### PR TITLE
Add CI Build and Dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,7 @@
+version: 2
+
+updates:
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,52 @@
+name: Build
+on: push
+
+jobs:
+  build:
+    name: Test Building
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Run package update
+        run: |
+          sudo apt update
+          sudo apt full-upgrade -y
+
+      - name: Install dependencies
+        run: |
+          sudo apt install git g++ cmake curl libopt-dev \
+            liblua5.1-dev libeigen3-dev \
+            libgoogle-perftools-dev \
+            libgoogle-glog-dev libgflags-dev \
+            libboost-all-dev libopencv-dev
+
+      - name: Install ROS
+        run: |
+          sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
+          curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | sudo apt-key add -
+          sudo apt update
+          sudo apt install ros-noetic-desktop
+          sudo apt install python3-rosdep python3-rosinstall-generator python3-wstool build-essential
+          sudo rosdep init
+          rosdep update
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+
+      - name: Install amrl_msgs
+        run: |
+          source /opt/ros/noetic/setup.bash
+          export ROS_PACKAGE_PATH=$ROS_PACKAGE_PATH:$GITHUB_WORKSPACE:$GITHUB_WORKSPACE/../amrl_msgs
+          cd $GITHUB_WORKSPACE/..
+          git clone https://github.com/ut-amrl/amrl_msgs.git
+          cd amrl_msgs
+          make
+
+      - name: Run build
+        run: |
+          source /opt/ros/noetic/setup.bash
+          export ROS_PACKAGE_PATH=$ROS_PACKAGE_PATH:$GITHUB_WORKSPACE:$GITHUB_WORKSPACE/../amrl_msgs
+          cd $GITHUB_WORKSPACE
+          make

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,7 +14,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt install git g++ cmake curl libopt-dev \
+          sudo apt install git g++ cmake curl libpopt-dev \
             liblua5.1-dev libeigen3-dev \
             libgoogle-perftools-dev \
             libgoogle-glog-dev libgflags-dev \

--- a/manifest.xml
+++ b/manifest.xml
@@ -15,7 +15,7 @@
   <depend package="rosbag"/>
   <depend package="tf"/>
   <depend package="amrl_msgs"/>
-  <depend package="amrl_maps"/>
+  <!-- <depend package="amrl_maps"/> -->
   <depend package="cv_bridge"/>
   <depend package="image_transport"/>
 


### PR DESCRIPTION
Adds a configuration for a GitHub Actions workflow that clones the project, installs the necessary dependencies, and passes if `make` can be run successfully. Also adds a configuration for dependabot to check daily for updates to submodules (e.g. `amrl_shared_lib` and `config_reader`).

## Additions
- `.github/workflows/build.yaml` is the GitHub Actions configuration
- `.github/dependabot.yaml` is the dependabot configuration

## Limitations
Right now, the CI is quite slow, with most of the time being spent installing dependencies. This could be sped up in the future by maybe using GitHub Action's caching feature, or more simply by using a Docker image with the dependencies included (this Docker image would be built and pushed from this repository as well).